### PR TITLE
Fix master

### DIFF
--- a/core/java/src/org/openda/utils/OpenDaTestSupport.java
+++ b/core/java/src/org/openda/utils/OpenDaTestSupport.java
@@ -439,6 +439,7 @@ public class OpenDaTestSupport {
 	
 	private static String removeIntsAndFloats(String line){
 		line=line.replaceAll("[0-9]*\\.?[0-9]+", "");
+		line=line.replaceAll(" ", "");
 		return line;
 	}
 	

--- a/model_delft3d/java/test/org/openda/model_delft3d/D3dMdFileDataObjectTest.java
+++ b/model_delft3d/java/test/org/openda/model_delft3d/D3dMdFileDataObjectTest.java
@@ -66,6 +66,6 @@ public class D3dMdFileDataObjectTest extends TestCase {
 
 		File mdFileOrg = new File(testData.getTestRunDataDir(), "simple-mdfile-out.mdf");
 		File mdFileExpected = new File(testData.getTestRunDataDir(), "simple-mdfile-expected.mdf");
-		assertTrue("Ajdusted file OK", testData.FilesAreIdentical(mdFileOrg, mdFileExpected));
+		assertTrue("Ajdusted file OK", testData.FilesAreIdentical(mdFileOrg, mdFileExpected, 0, 1.0e-8));
 	}
 }

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -14,6 +14,13 @@ cd core/native
 make install
 cd $HIER
 
+#build all castor stuff
+for DIRBUILD in model_delft3d core model_wflow model_efdc_dll model_bmi observers
+do
+   cd $DIRBUILD
+   ant -f build_castor.xml build
+   cd $HIER
+done
 ant build 
 
 echo DONE INSTALLING


### PR DESCRIPTION
Last few commits before migration caused tests to fail. This was cased by two test and build related issues:

*castor stuff was compiled with a 1.8 compiler hence the 1.7 tests fail (solution is to build castor stuff in test suite)

*Comparing ascii output does support precision testing but does not allow extra spaces. This has been changed