### PR TITLE
Update travis test to use jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 jdk:
   - openjdk7
   - oraclejdk8
-  - oraclejdk9
+  - oraclejdk11
 
 before_install:
   - sudo apt-get update


### PR DESCRIPTION
JDK 9 is end of life, JDK 11 is the latest with long time support 