### PR TITLE
Add unless test-only on build and testclasses targets

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -64,7 +64,7 @@
 	Compilation
 ===========================================================================
 -->
-   <target name="build" depends="init, tests">
+   <target name="build" depends="init, tests" unless="test-only">
       <buildmodule module="core" />
       <buildmodule module="observers" />
       <buildmodule module="models" />
@@ -542,7 +542,7 @@
 	-->
 
      <!-- compile test classes -->
-    <target name="testclasses">
+    <target name="testclasses" unless="test-only">
         <mkdir dir="${testbuilddir}"/>
     	<buildmoduletests module="core" />
     	<buildmoduletests module="observers" />
@@ -562,7 +562,7 @@
         <buildmoduletests module="model_openfoam"/>        
     </target>
 
-    <target name="testclassesPPC">
+    <target name="testclassesPPC" unless="test-only">
         <mkdir dir="${testbuilddir}"/>
     	<buildmoduletests module="core" />
     	<buildmoduletests module="observers" />


### PR DESCRIPTION
The normal `ant test` depends on `build` and `testclasses` targets.
This change is to enable the following procedure 
1. build with JDK 1.8 
2. test with OpenJDK11

We need to have the option to only run the test and not run the `build` and `testclasses` step. This is now an option when running
`ant test -Dtest_only`

Normal testing is not changed.
