### PR TITLE
Fixed unit conversion (mm to meter) in calculation of volumetric soil…

### DIFF
--- a/model_metaswap/java/src/org/openda/model_metaswap/SwapResultFile.java
+++ b/model_metaswap/java/src/org/openda/model_metaswap/SwapResultFile.java
@@ -58,7 +58,8 @@ public class SwapResultFile implements IDataObject {
 			while (lineElements != null && lineElements.length != 0) {
 				Double s01 = Double.valueOf(lineElements[s01Index]);
 				Double dprztb = Double.valueOf(lineElements[dprztbIndex]);
-				doubleValuesList.add(s01 / dprztb);
+				// added divide by 1000 to convert mm to m
+				doubleValuesList.add(s01 / dprztb / 1000);
 				int year = Integer.valueOf(lineElements[yearIndex]);
 				CALENDAR.clear();
 				CALENDAR.set(year, Calendar.JANUARY, 1);


### PR DESCRIPTION
OpenDA extracts the volumetric soil moisture content from MetaSWAP model result files. This pull request fixes a small bug in unit conversion.