### PR TITLE
Openda 2 4 disable debug output

### DIFF
--- a/core/native/src/cta/cta_handles.c
+++ b/core/native/src/cta/cta_handles.c
@@ -555,40 +555,54 @@ int CTA_Handle_Free_All(CTA_Handle *handle){
          if (IDEBUG>0) printf("Delete CTA_VECTOR\n");
          return CTA_Vector_Free(handle);
       case CTA_VECTORCLASS :
-         if (IDEBUG>0) printf("Delete CTA_VECTORCLASS\n");
-         printf("WARNING: Cannot delete CTA_VECTORCLASS\n");
+         if (IDEBUG>0) {
+            printf("Delete CTA_VECTORCLASS\n");
+            printf("WARNING: Cannot delete CTA_VECTORCLASS\n");
+         }
          return CTA_Handle_Free(handle);
       case CTA_TREEVECTOR :
          if (IDEBUG>0) printf("Delete CTA_TREEVECTOR\n");
          return CTA_TreeVector_Free(handle,CTA_TRUE);
       case CTA_MATRIXCLASS :
-         if (IDEBUG>0) printf("Delete CTA_MAXTRIXCLASS\n");
-         printf("WARNING: Cannot delete CTA_MATRIXCLASS\n");
+         if (IDEBUG>0) {
+            printf("Delete CTA_MAXTRIXCLASS\n");
+            printf("WARNING: Cannot delete CTA_MATRIXCLASS\n");
+         }
          return CTA_Handle_Free(handle);
       case CTA_MATRIX :
          if (IDEBUG>0) printf("Delete CTA_MATRIX\n");
          return CTA_Matrix_Free(handle);
       case CTA_COVMATCLASS :
-         if (IDEBUG>0) printf("Delete CTA_COVMATCLASS\n");
-         printf("WARNING: Cannot delete CTA_COVMATCLASS\n");
+         if (IDEBUG>0) {
+            printf("Delete CTA_COVMATCLASS\n");
+            printf("WARNING: Cannot delete CTA_COVMATCLASS\n");
+         }
          return CTA_Handle_Free(handle);
       case CTA_COVMAT :
-         if (IDEBUG>0) printf("Delete CTA_COVMAT\n");
-         printf("WARNING: Cannot delete CTA_COVMAT\n");
+         if (IDEBUG>0) { 
+            printf("Delete CTA_COVMAT\n");
+            printf("WARNING: Cannot delete CTA_COVMAT\n");
+         }
          return CTA_OK;
       //   return CTA_Handle_Free(handle);
       case CTA_INTPOL :
-         if (IDEBUG>0) printf("Delete CTA_INTPOL\n");
-         printf("WARNING: Cannot delete CTA_INTPOL\n");
+         if (IDEBUG>0) {
+            printf("Delete CTA_INTPOL\n");
+            printf("WARNING: Cannot delete CTA_INTPOL\n");
+         }
          return CTA_OK;
       //   return CTA_Handle_Free(handle);
       case CTA_OBS :
-         if (IDEBUG>0) printf("Delete CTA_OBS\n");
-         printf("WARNING: Cannot delete CTA_OBS\n");
+         if (IDEBUG>0) { 
+            printf("Delete CTA_OBS\n");
+            printf("WARNING: Cannot delete CTA_OBS\n");
+         }
          return CTA_OK;
       case CTA_MODELCLASS :
-         if (IDEBUG>0) printf("Delete CTA_MODELCLASS\n");
-         printf("WARNING: Cannot delete CTA_MODELCLASS\n");
+         if (IDEBUG>0) { 
+            printf("Delete CTA_MODELCLASS\n");
+            printf("WARNING: Cannot delete CTA_MODELCLASS\n");
+         }
          return CTA_OK;
       //   return CTA_Handle_Free(handle);
       case CTA_MODEL :
@@ -601,19 +615,25 @@ int CTA_Handle_Free_All(CTA_Handle *handle){
          if (IDEBUG>0) printf("Delete CTA_SOBS\n");
 		   return CTA_SObs_Free(handle);
       case CTA_SOBSCLASS :
-         if (IDEBUG>0) printf("Delete CTA_SOBCLASS\n");
-         printf("WARNING: Cannot delete CTA_OBSCLASS\n");
+         if (IDEBUG>0) {
+            printf("Delete CTA_SOBCLASS\n");
+            printf("WARNING: Cannot delete CTA_OBSCLASS\n");
+         }
          return CTA_OK;
       case CTA_OBSDESCR :
          if (IDEBUG>0) printf("Delete CTA_OBSDESCR\n");
 		   return CTA_ObsDescr_Free(handle);
       case CTA_METHODCLASS :
-         if (IDEBUG>0) printf("Delete CTA_METHODCLASS\n");
-         printf("WARNING: Cannot delete CTA_METHODCLASS\n");
+         if (IDEBUG>0) { 
+            printf("Delete CTA_METHODCLASS\n");
+            printf("WARNING: Cannot delete CTA_METHODCLASS\n");
+         }
          return CTA_OK;
       case CTA_METHOD :
-         if (IDEBUG>0) printf("Delete CTA_METHOD\n");
-         printf("WARNING: Cannot delete CTA_METHOD\n");
+         if (IDEBUG>0) { 
+            printf("Delete CTA_METHOD\n");
+            printf("WARNING: Cannot delete CTA_METHOD\n");
+         }
          return CTA_OK;
       case CTA_TREE :
          return CTA_Tree_Free(handle);
@@ -621,22 +641,28 @@ int CTA_Handle_Free_All(CTA_Handle *handle){
          if (IDEBUG>0) printf("Delete CTA_PACK\n");
          return CTA_Pack_Free(handle);
       case CTA_DATABLOCK :
-         if (IDEBUG>0) printf("Delete CTA_DATABLOCK\n");
-         printf("WARNING: Cannot delete CTA_DATABLOCK\n");
+         if (IDEBUG>0) {
+            printf("Delete CTA_DATABLOCK\n");
+            printf("WARNING: Cannot delete CTA_DATABLOCK\n");
+         }
          return CTA_OK;
       case CTA_METAINFO :
          if (IDEBUG>0) printf("Delete CTA_METAINFO\n");
          return CTA_Metainfo_Free(handle);
       case CTA_METAINFOCLASS :
-         if (IDEBUG>0) printf("Delete CTA_METAINFOCLASS\n");
-         printf("WARNING: Cannot delete CTA_METAINFOCLASS\n");
+         if (IDEBUG>0) {
+            printf("Delete CTA_METAINFOCLASS\n");
+            printf("WARNING: Cannot delete CTA_METAINFOCLASS\n");
+         }
          return CTA_OK;
       case CTA_RELTABLE :
          if (IDEBUG>0) printf("Delete CTA_RELTABLE\n");
          return CTA_RelTable_Free(handle);
       case CTA_SUBTREEVECTOR :
-         if (IDEBUG>0) printf("Delete CTA_SUBTREEVECTOR\n");
-         printf("WARNING: Cannot delete CTA_SUBTREEVECTOR\n");
+         if (IDEBUG>0) {
+            printf("Delete CTA_SUBTREEVECTOR\n");
+            printf("WARNING: Cannot delete CTA_SUBTREEVECTOR\n");
+         }
          return CTA_OK;
       case CTA_STRING :
          if (IDEBUG>0) printf("Delete CTA_STRING\n");

--- a/core/native/src/cta/cta_initialise.c
+++ b/core/native/src/cta/cta_initialise.c
@@ -28,14 +28,18 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "cta_sobs_netcdf.h"
 #include "cta_sobs_combine.h"
 #include "cta_sobs_sqlite3.h"
+#include "cta_message.h"
 
+#define CLASSNAME "CTA_Core"
 #define CTA_INITIALISE_F77 F77_CALL(cta_core_initialise,CTA_CORE_INITIALISE)
 #define CTA_FINALISE_F77 F77_CALL(cta_core_finalise,CTA_CORE_FINALISE)
 #define CTA_SOBS_MAORI_INITIALISE_F77 F77_CALL(cta_sobs_maori_initialise, CTA_SOBS_MAORI_INITIALISE)
 
+#define IDEBUG (0)
 
 int is_initialised=0;
 
+#define METHOD "Initialise"
 int CTA_Core_Initialise()
 {
 
@@ -48,7 +52,10 @@ int CTA_Core_Initialise()
    // Default library name for user routines
    strcpy(userDefaultDynamicLibrary,"libuseropenda");
 
-   printf("OpenDA Native initialize: Initial random seed %ld\n",CTA_INITIAL_RANDOM_SEED);
+   char message[64];
+   sprintf(message,"OpenDA Native initialize: Initial random seed %ld\n",CTA_INITIAL_RANDOM_SEED);
+   CTA_WRITE_INFO(message);
+
    CTA_rand_seed((long) CTA_INITIAL_RANDOM_SEED);
    if (! is_initialised)
    {
@@ -62,7 +69,6 @@ int CTA_Core_Initialise()
       CTA_SObs_combine_initialise(&CTA_COMBINE_SOBS);
 
       CTA_ObsDescr_table_initialise(&CTA_OBSDESCR_TABLE);
-
 
       CTA_Vector_blas_initialise (&CTA_DEFAULT_VECTOR);
 
@@ -95,26 +101,25 @@ int CTA_Core_Initialise()
 
       CTA_MODBUILD_PAR=CTA_NULL;
 
-      if (0) {
-      printf("cta_initialise :CTA_MODBUILD_PAR  =%d\n",CTA_MODBUILD_PAR);
-      printf("cta_initialise :CTA_FILE_STDOUT   =%d\n",CTA_FILE_STDOUT);
-      printf("cta_initialise :CTA_DEFAULT_SOBS  =%d\n",CTA_DEFAULT_SOBS);
-      printf("cta_initialise :CTA_NETCDF_SOBS   =%d\n",CTA_NETCDF_SOBS);
-      printf("cta_initialise :CTA_COMBINE_SOBS  =%d\n",CTA_COMBINE_SOBS);
-      printf("cta_initialise :CTA_OBSDESCR_TABLE=%d\n",CTA_OBSDESCR_TABLE);
-      printf("cta_initialise :CTA_DEFAULT_VECTOR=%d\n",CTA_DEFAULT_VECTOR);
-      printf("cta_initialise :CTA_DEFAULT_MATRIX=%d\n",CTA_DEFAULT_MATRIX);
-      printf("cta_initialise :CTA_MODBUILD_SP   =%d\n",CTA_MODBUILD_SP);
-      printf("cta_initialise :CTA_MODELCOMBINER =%d\n",CTA_MODELCOMBINER);
-      printf("cta_initialise :CTA_MODBUILD_B3B  =%d\n",CTA_MODBUILD_B3B);
-      printf("cta_initialise :CTA_MODBUILD_BB   =%d\n",CTA_MODBUILD_BB);
-      printf("cta_initialise :CTA_OP_ROOT_RMS   =%d\n",CTA_OP_ROOT_RMS);
-      printf("cta_initialise :CTA_OP_ROOT_AMAX  =%d\n",CTA_OP_ROOT_AMAX);
-      printf("cta_initialise :CTA_OP_ROOT_PRINTI=%d\n",CTA_OP_ROOT_PRINTI);
-      printf("cta_initialise :CTA_OP_ROOT_SSQ   =%d\n",CTA_OP_ROOT_SSQ);
-      printf("cta_initialise :CTA_MAORI_SOBS    =%d\n",CTA_MAORI_SOBS);
-      printf("cta_initialise :CTA_USER_SOBS     =%d\n",CTA_USER_SOBS);
-      exit(-1);
+      if (IDEBUG) {
+         printf("cta_initialise :CTA_MODBUILD_PAR  =%d\n",CTA_MODBUILD_PAR);
+         printf("cta_initialise :CTA_FILE_STDOUT   =%d\n",CTA_FILE_STDOUT);
+         printf("cta_initialise :CTA_DEFAULT_SOBS  =%d\n",CTA_DEFAULT_SOBS);
+         printf("cta_initialise :CTA_NETCDF_SOBS   =%d\n",CTA_NETCDF_SOBS);
+         printf("cta_initialise :CTA_COMBINE_SOBS  =%d\n",CTA_COMBINE_SOBS);
+         printf("cta_initialise :CTA_OBSDESCR_TABLE=%d\n",CTA_OBSDESCR_TABLE);
+         printf("cta_initialise :CTA_DEFAULT_VECTOR=%d\n",CTA_DEFAULT_VECTOR);
+         printf("cta_initialise :CTA_DEFAULT_MATRIX=%d\n",CTA_DEFAULT_MATRIX);
+         printf("cta_initialise :CTA_MODBUILD_SP   =%d\n",CTA_MODBUILD_SP);
+         printf("cta_initialise :CTA_MODELCOMBINER =%d\n",CTA_MODELCOMBINER);
+         printf("cta_initialise :CTA_MODBUILD_B3B  =%d\n",CTA_MODBUILD_B3B);
+         printf("cta_initialise :CTA_MODBUILD_BB   =%d\n",CTA_MODBUILD_BB);
+         printf("cta_initialise :CTA_OP_ROOT_RMS   =%d\n",CTA_OP_ROOT_RMS);
+         printf("cta_initialise :CTA_OP_ROOT_AMAX  =%d\n",CTA_OP_ROOT_AMAX);
+         printf("cta_initialise :CTA_OP_ROOT_PRINTI=%d\n",CTA_OP_ROOT_PRINTI);
+         printf("cta_initialise :CTA_OP_ROOT_SSQ   =%d\n",CTA_OP_ROOT_SSQ);
+         printf("cta_initialise :CTA_MAORI_SOBS    =%d\n",CTA_MAORI_SOBS);
+         printf("cta_initialise :CTA_USER_SOBS     =%d\n",CTA_USER_SOBS);
       }
    };
    return CTA_OK;
@@ -122,7 +127,7 @@ int CTA_Core_Initialise()
 
 
 int CTA_Core_Finalise(){
-   printf("Calling CTA_Finalise\n");
+   if (IDEBUG) printf("Calling CTA_Finalise\n");
    CTA_Modbuild_par_Finalize();
    return CTA_OK;
 }

--- a/core/native/src/cta/cta_modbuild_par.c
+++ b/core/native/src/cta/cta_modbuild_par.c
@@ -2033,7 +2033,7 @@ void CTA_Modbuild_par_worker_create(){
 
    /* Do we need to create our sratch model? */
    if (hmodel_scratch==CTA_NULL) {
-      printf("WARNING NOT CREATING SCRATCH MODEL\n");
+      if (IDEBUG>0){ printf("WARNING NOT CREATING SCRATCH MODEL\n"); }
 //      retval=CTA_Model_Create(hmodcl,smodinp,&hmodel_scratch);
 //      if (retval!=CTA_OK) {
 //         printf("#%d Failed to create scratch model\n",CTA_PAR_MY_RANK);

--- a/core/native/src/cta/cta_modbuild_par.c
+++ b/core/native/src/cta/cta_modbuild_par.c
@@ -69,7 +69,7 @@ void modbuild_models_add(CTA_Model hmodel){
    int iModel;
    CTA_Model *newList;
 
-   printf("Adding model %d\n",hmodel);
+   if (IDEBUG) printf("Adding model %d\n",hmodel);
    numCreatedModels++;
    newList= (CTA_Model*) CTA_Malloc(numCreatedModels*sizeof(CTA_Model));
    for (iModel=0; iModel<numCreatedModels-1; iModel++){

--- a/core/native/src/cta/cta_modbuild_sp.c
+++ b/core/native/src/cta/cta_modbuild_sp.c
@@ -1058,15 +1058,15 @@ void  modbuild_sp_ar1_covar(CTA_TreeVector *colsvar,int* nnoise, CTA_Handle husr
 
   CTA_Vector_Create(CTA_DEFAULT_VECTOR, 3, CTA_DOUBLE, CTA_NULL, &hvec1);
   ier2 = CTA_Tree_GetHandleStr(husrdata,"/p0",&hvec1);
-  printf ("-----------ar1_covar:tree: ier2=%d   \n",ier2);
+  if (IDEBUG) printf ("-----------ar1_covar:tree: ier2=%d   \n",ier2);
   ier2=CTA_Vector_GetVals(hvec1,p0,3,CTA_DOUBLE);
-  printf("ar1_covar: getvals ier p0 %d %f \n",ier2, p0[1]);
+  if (IDEBUG) printf("ar1_covar: getvals ier p0 %d %f \n",ier2, p0[1]);
 
   ier2 = CTA_Tree_GetHandleStr(husrdata,"/hgrid",&hhandle);
 
   ier2=CTA_Handle_GetData((CTA_Handle) hhandle,(void**) &hgrid);
 
-  printf("ar1_covar: ier2 grid.nx %d %d \n",ier2,hgrid->nx);
+  if (IDEBUG) printf("ar1_covar: ier2 grid.nx %d %d \n",ier2,hgrid->nx);
 
 
   ier2 = modbuild_sp_compute_covars(nmodel,Lar1,p0, *hgrid);
@@ -1078,7 +1078,7 @@ void  modbuild_sp_ar1_covar(CTA_TreeVector *colsvar,int* nnoise, CTA_Handle husr
     CTA_Vector_Create(CTA_DEFAULT_VECTOR, nmodel, CTA_DOUBLE, CTA_NULL, &hvec2);
     CTA_Vector_SetVals(hvec2,col1,nmodel,CTA_DOUBLE);
     CTA_TreeVector_SetVec(colsvar[i],hvec2);
-  printf("ar1_covar: state-setvec ier %d %d\n",i,ier2);
+    if (IDEBUG) printf("ar1_covar: state-setvec ier %d %d\n",i,ier2);
   }
 
   CTA_Vector_Free(&hvec1);

--- a/core/native/src/cta/cta_par.c
+++ b/core/native/src/cta/cta_par.c
@@ -298,8 +298,10 @@ void CTAI_Par_CreateMPIGroups(CTAI_Group *allGroups, int nGroups){
    nWork=nProcWorld-1;
 
    if (CTA_FILTER_PROCESS) {
-      if (IDEBUG) printf("#%d CTAI_Par_CreateMPIGroups: nProcWorld=%d\n",myRank,nProcWorld);
-      if (IDEBUG) printf("#%d CTAI_Par_CreateMPIGroups: nWork=%d\n",myRank, nWork);
+      if (IDEBUG) {
+         printf("#%d CTAI_Par_CreateMPIGroups: nProcWorld=%d\n",myRank,nProcWorld);
+         printf("#%d CTAI_Par_CreateMPIGroups: nWork=%d\n",myRank, nWork);
+      }
    }
 
    /* Check whether we have enough processes and set nTimes fields */
@@ -416,9 +418,11 @@ void CTAI_Par_CreateMPIGroups(CTAI_Group *allGroups, int nGroups){
 
             /* Set global communicators */
             if (isMyGroup) {
-               if (IDEBUG) printf("#%d I'm in group [%d,%d]\n",      myRankInWorld, iGroup+1,itime);
-               if (IDEBUG) printf("#%d CTA_COMM_MYWORLD       =%p\n",myRankInWorld, subCommNoMaster);
-               if (IDEBUG) printf("#%d CTA_COMM_MASTER_WORKER =%p\n",myRankInWorld, subCommWithMaster);
+               if (IDEBUG) {
+                  printf("#%d I'm in group [%d,%d]\n",      myRankInWorld, iGroup+1,itime);
+                  printf("#%d CTA_COMM_MYWORLD       =%p\n",myRankInWorld, subCommNoMaster);
+                  printf("#%d CTA_COMM_MASTER_WORKER =%p\n",myRankInWorld, subCommWithMaster);
+               }
 
                CTA_COMM_MYWORLD       = subCommNoMaster;
                CTA_COMM_MASTER_WORKER = subCommWithMaster;
@@ -564,22 +568,24 @@ int CTAI_Par_SetGroupInfo(CTA_Handle parConfig, CTAI_Group *group){
       }
    }
    if (CTA_FILTER_PROCESS) {
-      printf("----- OpenDA communication/model group information ------\n");
-      printf("Name of group           =%s\n",group->name);
-      printf("number of proccesses    =%d\n",group->nProc);
-      printf("Used for model          =%s\n",group->forModel);
-      printf("Number of replications  =%d\n",group->nTimes);
-      printf("Kind of parallelization =");
-      if (group->parType==WorkerWorker){
-         printf("WorkerWorker\n");
-      } else {
-         printf("MasterWorker\n");
-      }
-      printf("Spawn workers           =");
-      if (group->spawn_workers){
-         printf("Yes\n");
-      } else {
-         printf("No\n");
+      if (IDEBUG) {
+         printf("----- OpenDA communication/model group information ------\n");
+         printf("Name of group           =%s\n",group->name);
+         printf("number of proccesses    =%d\n",group->nProc);
+         printf("Used for model          =%s\n",group->forModel);
+         printf("Number of replications  =%d\n",group->nTimes);
+         printf("Kind of parallelization =");
+         if (group->parType==WorkerWorker){
+            printf("WorkerWorker\n");
+         } else {
+            printf("MasterWorker\n");
+         }
+         printf("Spawn workers           =");
+         if (group->spawn_workers){
+            printf("Yes\n");
+         } else {
+            printf("No\n");
+         }
       }
    }
    return CTA_OK;
@@ -613,8 +619,9 @@ int CTA_Par_WorkerSpawn(int StartPar){
    retval=MPI_Comm_size(CTA_COMM_WORLD, &comm_size);
    retval=MPI_Comm_rank(CTA_COMM_WORLD, &myRankInWorld);
 
-   if (myRankInWorld==0) printf("%s Number of processes that are spawned :%d\n",METHOD, comm_size);
-
+   if (IDEBUG) {
+      if (myRankInWorld==0) printf("%s Number of processes that are spawned :%d\n",METHOD, comm_size);
+   }
    /* Set rank of this process, note: this is not in the whole world! */
    CTA_PAR_MY_RANK=myRankInWorld;
 
@@ -635,12 +642,12 @@ int CTA_Par_WorkerSpawn(int StartPar){
 
    /* Do we need to start the modelbuilder */
    if (StartPar==CTA_TRUE) {
-      printf("=================================================\n");
-      printf("Starting the modelbuilder\n");
-      printf("Inter communicator is %p\n",CTA_COMM_MASTER_WORKER);
-      printf("=================================================\n");
-
-
+      if(IDEBUG) {
+         printf("=================================================\n");
+         printf("Starting the modelbuilder\n");
+         printf("Inter communicator is %p\n",CTA_COMM_MASTER_WORKER);
+         printf("=================================================\n");
+      }
       CTA_Modbuild_par_CreateClass(&CTA_MODBUILD_PAR);
    }
 #endif
@@ -668,7 +675,9 @@ int CTA_Par_CreateGroups(int parConfig, int StartPar){
    /* When this function is called we will always run in parallel */
    CTA_IS_PARALLEL=CTA_TRUE;
 
-   if (myRankInWorld==0) printf("CTA_Par_CreateGroups: Size of CTA_COMM_WORLD is %d\n",comm_size);
+   if (IDEBUG) {
+      if (myRankInWorld==0) printf("CTA_Par_CreateGroups: Size of CTA_COMM_WORLD is %d\n",comm_size);
+   }
 
    /* Get the rank of this process */
    MPI_Comm_rank(CTA_COMM_WORLD, &myRankInWorld);
@@ -684,14 +693,18 @@ int CTA_Par_CreateGroups(int parConfig, int StartPar){
    }
 
    /* Read configuration */
-   if (CTA_FILTER_PROCESS) printf("CTA_Par_CreateGroups: number of processes is %d\n",comm_size);
+   if (IDEBUG) {
+      if (CTA_FILTER_PROCESS) printf("CTA_Par_CreateGroups: number of processes is %d\n",comm_size);
+   }
 
    /* Count number of process groups */
    CTAI_Par_NumGroups(parConfig, &nGroups1, &nGroups2);
    CTAI_nGroups=nGroups1+nGroups2;
-   if (CTA_FILTER_PROCESS) printf("CTA_Par_CreateGroups: number groups defined globally  =%d\n",nGroups1);
-   if (CTA_FILTER_PROCESS) printf("CTA_Par_CreateGroups: number groups defined locally   =%d\n",nGroups2);
-   if (CTA_FILTER_PROCESS) printf("CTA_Par_CreateGroups: total number of defined ngroups =%d\n",CTAI_nGroups);
+   if (IDEBUG) {
+      if (CTA_FILTER_PROCESS) printf("CTA_Par_CreateGroups: number groups defined globally  =%d\n",nGroups1);
+      if (CTA_FILTER_PROCESS) printf("CTA_Par_CreateGroups: number groups defined locally   =%d\n",nGroups2);
+      if (CTA_FILTER_PROCESS) printf("CTA_Par_CreateGroups: total number of defined ngroups =%d\n",CTAI_nGroups);
+   }
 
    /* Get properties of the groups and store them in CTAI_AllGroups */
    CTAI_AllGroups=NULL;

--- a/core/native/src/cta/cta_sobs.c
+++ b/core/native/src/cta/cta_sobs.c
@@ -128,17 +128,17 @@ int CTA_SObs_Create(
    }
 
    /* determine size of data object (CTA_SOBS_CREATE_SIZE)*/
-   printf("CTA_SOBS: get CREATE_SIZE \n");
+   if (IDEBUG>0){ printf("CTA_SOBS: get CREATE_SIZE \n"); }
    retval=CTA_Func_GetFunc(clsdata->functions[CTA_SOBS_CREATE_SIZE],
                            &my_Create_Size);
-   printf("CTA_SOBS: done calling CREATE_SIZE %p\n",my_Create_Size);
+   if (IDEBUG>0){ printf("CTA_SOBS: done calling CREATE_SIZE %p\n",my_Create_Size); }
    if (retval!=CTA_OK) {
       CTA_WRITE_ERROR("Cannot get function CTA_SOB_CREATE_SIZE");
       return retval;
    }
-   printf("Calling my_create_size\n");
+   if (IDEBUG>0){ printf("Calling my_create_size\n"); }
    my_Create_Size(&memsize,&retval);
-   printf("DOne Calling my_create_size\n");
+   if (IDEBUG>0){ printf("DOne Calling my_create_size\n"); }
    if (retval) {
       CTA_WRITE_ERROR("Error in my_Create_Size");
       return retval;
@@ -152,7 +152,7 @@ int CTA_SObs_Create(
 
    /* copy function pointers */
    for (i=0;i<CTA_SOBS_NUMFUNC;i++){
-      printf("Member function[%d]=%d\n",i,clsdata->functions[i]);
+      if (IDEBUG>0) { printf("Member function[%d]=%d\n",i,clsdata->functions[i]); }
       sobs->functions[i]=clsdata->functions[i];
    }
 

--- a/core/native/src/cta/cta_sobs.c
+++ b/core/native/src/cta/cta_sobs.c
@@ -138,7 +138,7 @@ int CTA_SObs_Create(
    }
    if (IDEBUG>0){ printf("Calling my_create_size\n"); }
    my_Create_Size(&memsize,&retval);
-   if (IDEBUG>0){ printf("DOne Calling my_create_size\n"); }
+   if (IDEBUG>0){ printf("Done Calling my_create_size\n"); }
    if (retval) {
       CTA_WRITE_ERROR("Error in my_Create_Size");
       return retval;

--- a/core/native/src/cta/cta_util_statistics.c
+++ b/core/native/src/cta/cta_util_statistics.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "cta_datatypes.h"
 #include "cta_errors.h"
 #include "cta_util_statistics.h"
+#include "cta_message.h"
 
 #define CTA_RAND_U_F77  F77_CALL(cta_rand_u,CTA_RAND_U)
 #define CTA_RAND_N_F77  F77_CALL(cta_rand_n,CTA_RAND_N)
@@ -44,6 +45,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define NDIV (1+IMM1/NTAB) 
 #define EPS 1.2e-7
 #define RNMX (1.0-EPS)
+
+#define CLASSNAME "CTA_Utils_Statisctics"
 
 static long CTAI_current_state_random=-21075;
 
@@ -82,16 +85,16 @@ float ran2(long *idum)
         }
 }
 
-
+#define METHOD "CTA_rand_seed"
 void CTA_rand_seed(int seed){
-   printf("cta_util_statistics: Set initial seed: %ld\n",seed);
+   char message[64];
+   sprintf(message,"Set initial seed: %ld\n",seed);
+   CTA_WRITE_INFO(message);
    if (seed=0) seed=-21075;
    if (seed>0) seed=-seed;
    CTAI_current_state_random=(long) seed;
    ran2(&CTAI_current_state_random);
 }
-
-
 
 int CTA_rand_u(double *x)
 // Calculate a realization from a uniform [0 1] distribution
@@ -100,7 +103,6 @@ int CTA_rand_u(double *x)
    *x=(double) ran2(&CTAI_current_state_random);
    return CTA_OK;
 }
-
 
 int CTA_rand_n(double *x)
 // Calculate a realization from a standard normal distribution
@@ -146,6 +148,3 @@ CTAEXPORT void CTA_RAND_U_F77(double *x, int *ierr){
 CTAEXPORT void CTA_RAND_N_F77(double *x, int *ierr){
    *ierr=CTA_rand_n(x);
 }
-
-
-


### PR DESCRIPTION
The native (cta) core of OpenDA contains a lot of debug output.
The related print statements are now placed in a if (DEBUG) block.
Production code should be compiled with DEBUG = 0.

