### PR TITLE
Update script for teamcity on the DPC 

### DIFF
--- a/scripts/openda_build_linux64_teamcity.sh
+++ b/scripts/openda_build_linux64_teamcity.sh
@@ -5,7 +5,7 @@ module(){ eval $(/usr/bin/modulecmd bash $*);};
 export OPENDASCRIPTROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd ${OPENDASCRIPTROOT}/../..
 
-export GCCDIR=/opt/gcc/4.9.2
+export GCCDIR=/opt/apps/gcc/4.9.2
 #source /usr/share/Modules/init/bash
 module load gcc
 module load java/jdk_1.7_oracle


### PR DESCRIPTION
Volgens Tim van den Aardweg:

De Linux build die klaagt omdat er modules niet gevonden kunnen worden. Dat klopt: er wordt in de /ops/ folder gezocht, maar de modules staan in /opt/apps/. Het openda_build_linux64_teamcity.sh script dat jullie gebruiken moet dus even aangepast worden.