### PR TITLE
DFlow-FM fixes

### DIFF
--- a/core/java/src/org/openda/blackbox/wrapper/BBModelInstance.java
+++ b/core/java/src/org/openda/blackbox/wrapper/BBModelInstance.java
@@ -447,7 +447,7 @@ public class BBModelInstance extends Instance implements IModelInstance {
 
 		// copy the model's restart files to a subdirectory for the current time stap,
 		// and gather them in a file based model state
-		File savedStateDir = checkRestartDir(getCurrentTime(), false);
+		File savedStateDir = checkRestartDir(getCurrentTime(), false).getAbsoluteFile();
 		for (String restartFileName : bbModelConfig.getRestartFileNames()) {
 			File modelStateFile = new File(getModelRunDir(), restartFileName);
 			File file = new File(restartFileName);
@@ -487,7 +487,7 @@ public class BBModelInstance extends Instance implements IModelInstance {
         flushAndClearDataObjects(false);
 
 		FileBasedModelState modelState = (FileBasedModelState) savedInternalState;
-		File savedStateDir = checkRestartDir(getCurrentTime(), false);
+		File savedStateDir = checkRestartDir(getCurrentTime(), false).getAbsoluteFile();
 		modelState.setDirContainingModelstateFiles(savedStateDir);
 		modelState.restoreState();
 		for (String restartFileName : bbModelConfig.getRestartFileNames()) {
@@ -516,7 +516,7 @@ public class BBModelInstance extends Instance implements IModelInstance {
 	}
 
 	public IModelState loadPersistentState(File persistentStateFile) {
-		File dirForRestartFiles = checkRestartDir(getCurrentTime(), false);
+		File dirForRestartFiles = checkRestartDir(getCurrentTime(), false).getAbsoluteFile();
 		return FileBasedModelState.loadPersistenState(persistentStateFile, dirForRestartFiles);
 	}
 

--- a/core/java/src/org/openda/blackbox/wrapper/BBStochModelInstance.java
+++ b/core/java/src/org/openda/blackbox/wrapper/BBStochModelInstance.java
@@ -726,7 +726,7 @@ public class BBStochModelInstance extends Instance implements IStochModelInstanc
 	}
 
 	public IModelState saveInternalState() {
-		File dirForRestartFiles = checkRestartDir(getCurrentTime());
+		File dirForRestartFiles = checkRestartDir(getCurrentTime()).getAbsoluteFile();
         FileBasedModelState stochSavedModelState = new FileBasedModelState();
         stochSavedModelState.setDirContainingModelstateFiles(dirForRestartFiles);
 		int i = 0;
@@ -762,7 +762,7 @@ public class BBStochModelInstance extends Instance implements IStochModelInstanc
 					" for " + this.getClass().getName() + ".releaseInternalState");
 		}
 		FileBasedModelState stochModelState = (FileBasedModelState) savedInternalState;
-		File dirForRestartFiles = checkRestartDir(getCurrentTime());
+		File dirForRestartFiles = checkRestartDir(getCurrentTime()).getAbsoluteFile();
         File incomingStateDir = stochModelState.getDirContainingModelStateFiles();
 
         // the particle filter exchanges full states. Copy a full state dir from another ensemble member
@@ -804,7 +804,7 @@ public class BBStochModelInstance extends Instance implements IStochModelInstanc
 	}
 
 	public IModelState loadPersistentState(File persistentStateFile) {
-		File dirForRestartFiles = checkRestartDir(getCurrentTime());
+		File dirForRestartFiles = checkRestartDir(getCurrentTime()).getAbsoluteFile();
 		return FileBasedModelState.loadPersistenState(persistentStateFile, dirForRestartFiles);
 	}
 

--- a/model_dflowfm_blackbox/java/src/org/openda/model_dflowfm/BcFileReaderWriter.java
+++ b/model_dflowfm_blackbox/java/src/org/openda/model_dflowfm/BcFileReaderWriter.java
@@ -81,7 +81,7 @@ public class BcFileReaderWriter
 						}
 					} else {
 						List<BcQuantity> table = lastCategory.getTable();
-						String[] values = nextLine.split("[ ]{1,}");
+						String[] values = nextLine.split("[\\s]{1,}");
 						if (table.size() != values.length)
 							throw new IllegalArgumentException("Number of values does not match number of quantities");
 

--- a/model_dflowfm_blackbox/java/src/org/openda/model_dflowfm/DFlowFMRestartFileWrapper.java
+++ b/model_dflowfm_blackbox/java/src/org/openda/model_dflowfm/DFlowFMRestartFileWrapper.java
@@ -95,7 +95,7 @@ public class DFlowFMRestartFileWrapper implements IDataObject {
 			netcdffileName = fileNameFull.getAbsolutePath();
 			inputFile = NetcdfFile.open(netcdffileName, null);
 		} catch (Exception e) {
-			throw new RuntimeException("DFlowFMRestartFileWrapper: problem opening file "+ this.fileName);
+			throw new RuntimeException("DFlowFMRestartFileWrapper: problem opening file "+ this.fileName + " due to " + e.getMessage(), e);
 		}
 
 		// get list of all variables and construct a smaller list of exchange variables from this list:
@@ -126,9 +126,9 @@ public class DFlowFMRestartFileWrapper implements IDataObject {
 						}
 					}
 				} catch (IOException e) {
-					throw new RuntimeException("Error reading array 'time' from NetCDF file "+netcdffileName);
+					throw new RuntimeException("Error reading array 'time' from NetCDF file "+ netcdffileName + " due to " + e.getMessage(), e);
 				} catch (InvalidRangeException e) {
-					throw new RuntimeException("Error reading from NetCDF file "+netcdffileName);
+					throw new RuntimeException("Error reading from NetCDF file "+ netcdffileName + " due to " + e.getMessage(), e);
 				}
 			}
 		}
@@ -151,10 +151,8 @@ public class DFlowFMRestartFileWrapper implements IDataObject {
     		try {
 	    		Array full = inputFile.readSection(var.getShortName());
 			    thisValue = full.slice(0,time_index);
-		    } catch (IOException e) {
-			   	e.printStackTrace();
-		    } catch (InvalidRangeException e) {
-			  	 e.printStackTrace();
+			} catch (IOException | InvalidRangeException e) {
+				throw new RuntimeException("Error reading from NetCDF file " + netcdffileName + " due to " + e.getMessage(), e);
 			} catch (ArrayIndexOutOfBoundsException e) {
 				System.out.println("Error processing "+var.getShortName());
 				continue;
@@ -203,6 +201,11 @@ public class DFlowFMRestartFileWrapper implements IDataObject {
 				}
 			}
 			inputFile.finish();
+		}
+		try {
+			inputFile.close();
+		} catch (IOException e) {
+			throw new RuntimeException("Error closing NetCDF file " + netcdffileName + " due to " + e.getMessage(), e);
 		}
 	}
 
@@ -260,7 +263,7 @@ public class DFlowFMRestartFileWrapper implements IDataObject {
 						try {
 							netcdfFileWriter.write(myVar,array);
 						} catch (InvalidRangeException e) {
-							e.printStackTrace();
+							throw new RuntimeException("Error writing to NetCDF file " + netcdffileName + " due to " + e.getMessage(), e);
 						}
 					}
 					else {
@@ -273,7 +276,7 @@ public class DFlowFMRestartFileWrapper implements IDataObject {
 			netcdfFileWriter.close();
 
 		} catch (IOException e) {
-			e.printStackTrace();
+			throw new RuntimeException("Error writing to NetCDF file " + netcdffileName + " due to " + e.getMessage(), e);
 		}
 	}
 

--- a/model_dflowfm_blackbox/java/test/org/openda/model_dflowfm/BcFileTest.java
+++ b/model_dflowfm_blackbox/java/test/org/openda/model_dflowfm/BcFileTest.java
@@ -25,6 +25,7 @@ import org.openda.utils.OpenDaTestSupport;
 import org.openda.utils.io.AsciiFileUtils;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -68,6 +69,30 @@ public class BcFileTest extends TestCase
 		// Step 4: Compare written file to expected results
         assertTrue(FileComparer.CompareIniFiles(new File(testBcFileDir, bcFileNameTimeSeriesValuesHalved),
 				new File(testBcFileDir, bcFileNameGenerated)));
+	}
+
+	public void testBcFileWithTabs()
+	{
+		// Step 1: Read original test file
+		BcFile bcFile = new BcFile();
+		bcFile.initialize(testBcFileDir, new String[]{"BoundaryConditions_tabs.bc", "BoundaryConditions_tabs_generated.bc"});
+
+		// Step 2: Alter ExchangeItem Values
+		String[] exchangeItemIDs = bcFile.getExchangeItemIDs();
+		for(String id : exchangeItemIDs)
+		{
+			IExchangeItem exchangeItem = bcFile.getDataObjectExchangeItem(id);
+			double[] multiplicationFactors = new double[exchangeItem.getValuesAsDoubles().length];
+			Arrays.fill(multiplicationFactors, 0.5);
+			exchangeItem.multiplyValues(multiplicationFactors);
+		}
+
+		//Step 3: Write test file
+		bcFile.finish();
+
+		// Step 4: Compare written file to expected results
+		assertTrue(FileComparer.CompareIniFiles(new File(testBcFileDir, "BoundaryConditions_tabs_expected.bc"),
+			new File(testBcFileDir, "BoundaryConditions_tabs_generated.bc")));
 	}
 
 	public void testBcFileWaterLevel() {

--- a/model_dflowfm_blackbox/java/test/org/openda/model_dflowfm/testData/BcFile/BoundaryConditions_tabs.bc
+++ b/model_dflowfm_blackbox/java/test/org/openda/model_dflowfm/testData/BcFile/BoundaryConditions_tabs.bc
@@ -1,0 +1,101 @@
+# Generated on 11/20/2015 15:30:45
+
+[General]
+    majorVersion          = 1
+    minorVersion          = 0
+    fileType              = boundConds
+
+[Boundary]
+    name                  = Node001
+    function              = constant
+    time-interpolation    = linear
+    quantity              = water_discharge
+    unit                  = m³/s
+    19.63
+
+[Boundary]
+    name                  = Node002
+    function              = constant
+    time-interpolation    = linear
+    quantity              = water_level
+    unit                  = m
+    13.57
+
+[Boundary]
+    name                  = Node003
+    function              = timeseries
+    time-interpolation    = linear
+    quantity              = time
+    unit                  = minutes since 2015-11-20 00:00:00
+    quantity              = water_discharge
+    unit                  = m³/s
+    920.5	11.13
+    980.5	13.17
+    1040.5	17.19
+    1100.5	19.23
+    1160.5	23.29
+
+[Boundary]
+    name                  = Node004
+    function              = qhtable
+    time-interpolation    = linear
+    quantity              = water_level
+    unit                  = m
+    quantity              = water_discharge
+    unit                  = m³/s
+    11.13	51.13
+    13.17	53.17
+    17.19	57.19
+    19.23	59.23
+    23.29	63.29
+
+[Boundary]
+    name                  = Node005
+    function              = timeseries
+    time-interpolation    = linear
+    quantity              = time
+    unit                  = minutes since 2015-11-20 00:00:00
+    quantity              = water_level
+    unit                  = m
+    920.5	11.13
+    980.5	13.17
+    1040.5	17.19
+    1100.5	19.23
+    1160.5	23.29
+
+[LateralDischarge]
+    name                  = Lateral001
+    function              = constant
+    time-interpolation    = linear
+    quantity              = water_discharge
+    unit                  = m³/s
+    47.92
+
+[LateralDischarge]
+    name                  = Lateral002
+    function              = timeseries
+    time-interpolation    = linear
+    quantity              = time
+    unit                  = minutes since 2015-11-20 00:00:00
+    quantity              = water_discharge
+    unit                  = m³/s
+    920.5	11.13
+    980.5	13.17
+    1040.5	17.19
+    1100.5	19.23
+    1160.5	23.29
+
+[LateralDischarge]
+    name                  = Lateral003
+    function              = qhtable
+    time-interpolation    = linear
+    quantity              = water_level
+    unit                  = m
+    quantity              = water_discharge
+    unit                  = m³/s
+    11.13	51.13
+    13.17	53.17
+    17.19	57.19
+    19.23	59.23
+    23.29	63.29
+

--- a/model_dflowfm_blackbox/java/test/org/openda/model_dflowfm/testData/BcFile/BoundaryConditions_tabs_expected.bc
+++ b/model_dflowfm_blackbox/java/test/org/openda/model_dflowfm/testData/BcFile/BoundaryConditions_tabs_expected.bc
@@ -1,0 +1,101 @@
+# Generated on 04/21/2021 10:45:02
+
+[General]
+    majorVersion          = 1
+    minorVersion          = 0
+    fileType              = boundConds
+
+[Boundary]
+    name                  = Node001
+    function              = constant
+    time-interpolation    = linear
+    quantity              = water_discharge
+    unit                  = m³/s
+    19.63 
+
+[Boundary]
+    name                  = Node002
+    function              = constant
+    time-interpolation    = linear
+    quantity              = water_level
+    unit                  = m
+    13.57 
+
+[Boundary]
+    name                  = Node003
+    function              = timeseries
+    time-interpolation    = linear
+    quantity              = time
+    unit                  = minutes since 2015-11-20 00:00:00
+    quantity              = water_discharge
+    unit                  = m³/s
+    920.5 5.565 
+    980.5 6.585 
+    1040.5 8.595 
+    1100.5 9.615 
+    1160.5 11.645 
+
+[Boundary]
+    name                  = Node004
+    function              = qhtable
+    time-interpolation    = linear
+    quantity              = water_level
+    unit                  = m
+    quantity              = water_discharge
+    unit                  = m³/s
+    11.13 51.13 
+    13.17 53.17 
+    17.19 57.19 
+    19.23 59.23 
+    23.29 63.29 
+
+[Boundary]
+    name                  = Node005
+    function              = timeseries
+    time-interpolation    = linear
+    quantity              = time
+    unit                  = minutes since 2015-11-20 00:00:00
+    quantity              = water_level
+    unit                  = m
+    920.5 5.565 
+    980.5 6.585 
+    1040.5 8.595 
+    1100.5 9.615 
+    1160.5 11.645 
+
+[LateralDischarge]
+    name                  = Lateral001
+    function              = constant
+    time-interpolation    = linear
+    quantity              = water_discharge
+    unit                  = m³/s
+    47.92 
+
+[LateralDischarge]
+    name                  = Lateral002
+    function              = timeseries
+    time-interpolation    = linear
+    quantity              = time
+    unit                  = minutes since 2015-11-20 00:00:00
+    quantity              = water_discharge
+    unit                  = m³/s
+    920.5 5.565 
+    980.5 6.585 
+    1040.5 8.595 
+    1100.5 9.615 
+    1160.5 11.645 
+
+[LateralDischarge]
+    name                  = Lateral003
+    function              = qhtable
+    time-interpolation    = linear
+    quantity              = water_level
+    unit                  = m
+    quantity              = water_discharge
+    unit                  = m³/s
+    11.13 51.13 
+    13.17 53.17 
+    17.19 57.19 
+    19.23 59.23 
+    23.29 63.29 
+


### PR DESCRIPTION
Fixed multiple small things for DFlow-FM

Usage of absolute path for state saving/loading on Linux
Properly closing of file and throwing exceptions instead of "on error continue"
Support usage of all whitespaces instead of just spaces in bc files