### PR TITLE
compile errors when using gfortran 10 or later

### DIFF
--- a/ci_compile_native.sh
+++ b/ci_compile_native.sh
@@ -3,6 +3,7 @@
 
 pushd core/native
 ./autoreconf_fix.sh
-./configure
+#Added flags due to stricter gfortran 10
+./configure FFLAGS=-fallow-argument-mismatch FCFLAGS=-fallow-argument-mismatch
 make install
 popd


### PR DESCRIPTION
added flags to disable stricter checks from gfortran 10 and later sin…ce we are not planing to fix/improve the native fortran code at this moment