### PR TITLE
Fix regression

### DIFF
--- a/model_efdc_dll/java/src/org/openda/model_efdc_dll/EfdcModelFactory.java
+++ b/model_efdc_dll/java/src/org/openda/model_efdc_dll/EfdcModelFactory.java
@@ -144,7 +144,7 @@ public class EfdcModelFactory implements IModelFactory, ITimeHorizonConsumer {
 		efdcEventTox2InpDataObject.initialize(templateDir,
 				new String[]{EVENT_TOX2_INP_FILE_NAME, String.valueOf(timeZoneOffsetInHours), TSTART, TSTOP});
 		for (String id : efdcEventTox2InpDataObject.getExchangeItemIDs()) {
-			IExchangeItem exchangeItem = efdcInpDataObject.getDataObjectExchangeItem(id);
+			IExchangeItem exchangeItem = efdcEventTox2InpDataObject.getDataObjectExchangeItem(id);
 			if (TSTART.equals(id)) {
 				exchangeItem.setValuesAsDoubles(new double[]{startTime});
 			} else if (TSTOP.equals(id)) {


### PR DESCRIPTION
The dates in `EVENT_TOX2.INP` are not correctly set with information from the FEWS `run_info.xml` file.
This is due to a regression in https://github.com/OpenDA-Association/OpenDA/commit/155f33ed420247c78c46c71ab99722bf7ade5f30#diff-883bfef1fd910d99c8c4ed3a2e7737d4f99523d009adb019f194a01073b11ae3