### PR TITLE
Updates to LaTeX files

### DIFF
--- a/course/doc/latex/exercise_1b.tex
+++ b/course/doc/latex/exercise_1b.tex
@@ -11,19 +11,19 @@ The dynamics of a double-pendulum can be descibed with the following equations
 
 variables $\theta_1, \theta_2, p_{\theta_1}, p_{\theta_2}$:
 \begin{eqnarray}
-   \frac{d \theta_1}{dt}= \frac{6}{m l^2} \frac{2 p_{\theta_1} - 3cos(\theta_1-\theta_2) p_{\theta_2}}
-   {16-9 cos^2(\theta_1-\theta_2)}\\
-   \frac{d \theta_2}{dt}= \frac{6}{m l^2} \frac{8 p_{\theta_2} - 3cos(\theta_1-\theta_2) p_{\theta_1}}
-   {16-9 cos^2(\theta_1-\theta_2)}\\
-   \frac{dp_{\theta_1}}{dt} = -\frac{1}{2} ml^2 \left( \frac{d \theta_1}{dt} \frac{d \theta_2}{dt} sin(\theta_1-\theta_2) + 3\frac{g}{l} sin(\theta_1) \right)  \\
-   \frac{dp_{\theta_1}}{dt} = -\frac{1}{2} ml^2 \left( -\frac{d \theta_1}{dt} \frac{d \theta_2}{dt} sin(\theta_1-\theta_2) + \frac{g}{l} sin(\theta_2) \right) 
+   \frac{d \theta_1}{dt}= \frac{6}{m l^2} \frac{2 p_{\theta_1} - 3\cos(\theta_1-\theta_2) p_{\theta_2}}
+   {16-9 \cos^2(\theta_1-\theta_2)}\\
+   \frac{d \theta_2}{dt}= \frac{6}{m l^2} \frac{8 p_{\theta_2} - 3\cos(\theta_1-\theta_2) p_{\theta_1}}
+   {16-9 \cos^2(\theta_1-\theta_2)}\\
+   \frac{dp_{\theta_1}}{dt} = -\frac{1}{2} ml^2 \left( \frac{d \theta_1}{dt} \frac{d \theta_2}{dt} \sin(\theta_1-\theta_2) + 3\frac{g}{l} \sin(\theta_1) \right)  \\
+   \frac{dp_{\theta_1}}{dt} = -\frac{1}{2} ml^2 \left( -\frac{d \theta_1}{dt} \frac{d \theta_2}{dt} \sin(\theta_1-\theta_2) + \frac{g}{l} \sin(\theta_2) \right) 
 \end{eqnarray}
 where the $x,y$-position of the middle of the two segments can be computed as:
 \begin{eqnarray}
-   x_1 = \frac{l}{2} sin(\theta_1) \\
-   y_1 = \frac{-l}{2} cos(\theta_1) \\
-   x_2 = l ( sin(\theta_1) + \frac{1}{2} sin(\theta_2) ) \\
-   y_2 = -l ( cos(\theta_1) + \frac{1}{2} cos(\theta_2) )
+   x_1 = \frac{l}{2} \sin(\theta_1) \\
+   y_1 = \frac{-l}{2} \cos(\theta_1) \\
+   x_2 = l ( \sin(\theta_1) + \frac{1}{2} \sin(\theta_2) ) \\
+   y_2 = -l ( \cos(\theta_1) + \frac{1}{2} \cos(\theta_2) )
 \end{eqnarray}
 
 This model, although simple, is very nonlinear and has a chaotic nature.  Its

--- a/course/doc/latex/openda_course.tex
+++ b/course/doc/latex/openda_course.tex
@@ -5,6 +5,15 @@
 \newif\ifshowmatlab
 \showmatlabtrue
 
+\usepackage{hyperref}
+\hypersetup{
+    colorlinks=true,
+    linkcolor=blue,
+    urlcolor=blue,
+    citecolor=blue,
+    linktoc=all,
+}
+
 
 %opening
 \title{OpenDA Course and Exercises}
@@ -39,7 +48,7 @@
 \section*{Installation of OpenDA}
 Before you can start with the exercises you must first install OpenDA. For the
 latest instructions, you are referred to \verb|$OPENDA/doc/OpenDA_domunentation.pdf|, 
-section ``Installation'' or the same document on our website \verb|www.openda.org|.
+section ``Installation'' or the same document on our website \url{www.openda.org}.
 
 \section{Getting started: Lorenz 3 variable model}
 \input{exercise_1a}

--- a/course/doc/latex/openda_course.tex
+++ b/course/doc/latex/openda_course.tex
@@ -44,6 +44,7 @@
 %\begin{abstract}
 
 %\end{abstract}
+\tableofcontents
 
 \section*{Installation of OpenDA}
 Before you can start with the exercises you must first install OpenDA. For the

--- a/course/doc/latex/openda_course.tex
+++ b/course/doc/latex/openda_course.tex
@@ -7,7 +7,7 @@
 
 
 %opening
-\title{OpenDA course and exercises}
+\title{OpenDA Course and Exercises}
 \author{Nils van Velzen, Martin Verlaan, Stef Hummel}
 
 \begin{document}


### PR DESCRIPTION
This pull request contains updates to two LaTeX files used in the OpenDA documentation (https://docs.openda.org/en/readthedocs/OpenDA_course.html). The changes include:

- Correcting typos in the LaTeX code by changing `sin` to `\sin` and `cos` to `\cos`.

- Capitalizing words in the title.

- Adding a table of contents with hyperlinks to improve readability.

- Using `\url{www.openda.org}` to create a hyperlink to the website.

These changes will improve the accuracy, clarity, and accessibility of the documentation.