### PR TITLE
Skip gain for high difference observation model results

### DIFF
--- a/algorithms/java/src/org/openda/algorithms/kalmanFilter/SteadyStateFilter.java
+++ b/algorithms/java/src/org/openda/algorithms/kalmanFilter/SteadyStateFilter.java
@@ -218,7 +218,10 @@ public class SteadyStateFilter extends AbstractSequentialAlgorithm {
 				double observedValue = innovation.getValue(i);
 				double predictionValue = pred_a.getValue(i);
 				// Skip assimilation when observations and predictions differ more than observation standard deviations times skipAssimilationStandardDeviationFactor
-				if (Math.abs(observedValue - predictionValue) > skipAssimilationStandardDeviationFactor * standardDeviations.getValue(i)) continue;
+				if (Math.abs(observedValue - predictionValue) > skipAssimilationStandardDeviationFactor * standardDeviations.getValue(i)) {
+					Results.putProgression("Info: Skipping assimilation for " + gainVectorId + " because innovation > (skipAssimilationStandardDeviationFactor * obs standard deviation). Observed value = " + observedValue + ", model prediction value " + predictionValue + ", skipAssimilationStandardDeviationFactor = "+ skipAssimilationStandardDeviationFactor + ", obs stdv = " + standardDeviations.getValue(i));
+					continue;
+				}
 				delta.axpy(observedValue, gainVector);
 			}else{
 				throw new RuntimeException("No matching column found for observation with id="

--- a/algorithms/java/src/org/openda/algorithms/kalmanFilter/SteadyStateFilter.java
+++ b/algorithms/java/src/org/openda/algorithms/kalmanFilter/SteadyStateFilter.java
@@ -219,7 +219,7 @@ public class SteadyStateFilter extends AbstractSequentialAlgorithm {
 				double predictionValue = pred_a.getValue(i);
 				// Skip assimilation when observations and predictions differ more than observation standard deviations times skipAssimilationStandardDeviationFactor
 				if (Math.abs(observedValue - predictionValue) > skipAssimilationStandardDeviationFactor * standardDeviations.getValue(i)) {
-					Results.putProgression("Info: Skipping assimilation for " + gainVectorId + " because innovation > (skipAssimilationStandardDeviationFactor * obs standard deviation). Observed value = " + observedValue + ", model prediction value " + predictionValue + ", skipAssimilationStandardDeviationFactor = "+ skipAssimilationStandardDeviationFactor + ", obs stdv = " + standardDeviations.getValue(i));
+					Results.putProgression("Info: Skipping assimilation for " + gainVectorId + " because innovation > (skipAssimilationStandardDeviationFactor * obs standard deviation). Observed value = " + observedValue + ", model prediction value " + predictionValue + ", skipAssimilationStandardDeviationFactor = "+ skipAssimilationStandardDeviationFactor + ", obs stdv = " + standardDeviations.getValue(i) +"\n");
 					continue;
 				}
 				delta.axpy(observedValue, gainVector);

--- a/algorithms/java/src/org/openda/algorithms/kalmanFilter/SteadyStateFilter.java
+++ b/algorithms/java/src/org/openda/algorithms/kalmanFilter/SteadyStateFilter.java
@@ -53,7 +53,7 @@ public class SteadyStateFilter extends AbstractSequentialAlgorithm {
 	private double[] gainTimeMjd;
 	private double[] readGainTime;
 	private int steadyStateTimeCounter = 0;
-	private double skipGainStandardDeviationFactor = Double.NEGATIVE_INFINITY;
+	private double skipAssimilationStandardDeviationFactor = Double.NEGATIVE_INFINITY;
 
 	public void initialize(File workingDir, String[] arguments) {
 		super.initialize(workingDir, arguments);
@@ -150,7 +150,7 @@ public class SteadyStateFilter extends AbstractSequentialAlgorithm {
                 i++;
             }
 		}
-		this.skipGainStandardDeviationFactor = this.configurationAsTree.getAsDouble("skipGainStandardDeviationFactor", Double.NEGATIVE_INFINITY);
+		this.skipAssimilationStandardDeviationFactor = this.configurationAsTree.getAsDouble("skipAssimilationStandardDeviationFactor", Double.NEGATIVE_INFINITY);
 		
 		//now read the first gain file into memory
         steadyStateTimeCounter++;
@@ -217,8 +217,8 @@ public class SteadyStateFilter extends AbstractSequentialAlgorithm {
 				if (gainVector.getSize() != delta.getSize()) Results.putMessage("Warning: Kalman Gain does not have exact same size as current state, this can cause suboptimal results. Please check if the contents of the state match the contents of the Kalman Gain.");
 				double observedValue = innovation.getValue(i);
 				double predictionValue = pred_a.getValue(i);
-				// Skip gain when observations and predictions differ more than observation standard deviations times skipGainStandardDeviationFactor
-				if (Math.abs(observedValue - predictionValue) > skipGainStandardDeviationFactor * standardDeviations.getValue(i)) continue;
+				// Skip assimilation when observations and predictions differ more than observation standard deviations times skipAssimilationStandardDeviationFactor
+				if (Math.abs(observedValue - predictionValue) > skipAssimilationStandardDeviationFactor * standardDeviations.getValue(i)) continue;
 				delta.axpy(observedValue, gainVector);
 			}else{
 				throw new RuntimeException("No matching column found for observation with id="

--- a/core/xmlSchemas/algorithm/steadyStateFilter.xsd
+++ b/core/xmlSchemas/algorithm/steadyStateFilter.xsd
@@ -72,7 +72,12 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
-			</xs:sequence>
+        <xs:element name="skipGainStandardDeviationFactor" type="xs:double">
+          <xs:annotation>
+            <xs:documentation>Skip gain when the model results differ from the observations more than this factor times the standard deviation of the observations</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
 		</xs:complexType>
 	</xs:element>
 </xs:schema>

--- a/core/xmlSchemas/algorithm/steadyStateFilter.xsd
+++ b/core/xmlSchemas/algorithm/steadyStateFilter.xsd
@@ -72,7 +72,7 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
-        <xs:element name="skipGainStandardDeviationFactor" type="xs:double">
+        <xs:element name="skipAssimilationStandardDeviationFactor" type="xs:double">
           <xs:annotation>
             <xs:documentation>Skip gain when the model results differ from the observations more than this factor times the standard deviation of the observations</xs:documentation>
           </xs:annotation>


### PR DESCRIPTION
In an operational context it can happen that model results are temporarily disturbed due to unforeseen circumstances like network issues. In that case it can be undesirable to let that affect the Kalman gain. Therefore an option will be build in the SSFK to skip the gain when the model results from the observations differ more than x.x times the standard deviation of the observations.