### PR TITLE
Update conf.py and upload artifact v4 for readthedocs and GitHub action updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: bash ci_test.sh
       - name: Archive test reports
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ant-test-reports
           path: opendaTestReports

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,3 +26,20 @@ exclude_patterns = []
 
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
+
+
+
+
+# -- Fix for supporting readthe docs on a custom domain -----------------------
+# https://about.readthedocs.com/blog/2024/07/addons-by-default/
+
+import os
+
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True


### PR DESCRIPTION
Readthedocs has recently updated the way their configuration is managed.

A fix was needed to ensure everything remained functional (though to be honest I did not see anything break).

This PR is this fix :-)

https://about.readthedocs.com/blog/2024/07/addons-by-default/

Coincidentally, the GitHub action also broke in this PR as one of the actions needed updating.

So this PR is that fix too ;-)